### PR TITLE
The install instructions were just a bit off

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -50,7 +50,7 @@ All these are automatically installed if you use gem install -y
 
 == INSTALL:
 
-* sudo gem install -y mailshovel
+* sudo gem install -y mailtrap
 
 == LICENSE:
 


### PR DESCRIPTION
$ git diff HEAD^ HEAD
diff --git a/README.txt b/README.txt
index 40ed36d..5b095d7 100644
--- a/README.txt
+++ b/README.txt
@@ -50,7 +50,7 @@ All these are automatically installed if you use gem install -y

 == INSTALL:

-\* sudo gem install -y mailshovel
+\* sudo gem install -y mailtrap
