### PR TITLE
Fix problem with minitest 5 + test/unit incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
     gem 'hoe-gemspec'
     gem 'hoe-git'
     gem 'rspec'
+    gem 'minitest', '~> 4.7', :platforms => :ruby_19
     gem 'rake'
     gem 'rdoc'
     gem 'shoulda'

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,9 @@ Hoe.plugin :gemspec
 Hoe.plugin :git
 
 Hoe.spec "mailtrap" do
- self.rubyforge_name = 'simplyruby'
+ #self.rubyforge_name = 'simplyruby' ## Rubyforge shut down
  developer 'Matt Mower', 'self@mattmower.com'
+ developer 'James Cuzella', 'james.cuzella@lyraphase.com'
  #summary 'Mailtrap is a mock SMTP server for use in Rails development'
  #description self.paragraphs_of('README.txt', 0).first.split(/\n/)[1..-1]
  #url self.paragraphs_of('README.txt', 0).first.split(/\n/)[1..-1]
@@ -20,6 +21,12 @@ Hoe.spec "mailtrap" do
  extra_deps << ['daemons','>= 1.0.8'] 
  extra_deps << ['trollop','>= 1.7']
  extra_deps << ['mail','~> 2.3.0']
+
+ extra_dev_deps << ["rspec", "~> 3.0"]
+ extra_dev_deps << ["simplecov", "~> 0.9"]
+ extra_dev_deps << ["bundler", "~> 1.6"]
+ extra_dev_deps << ["rake", "~> 10.0"]
+ extra_dev_deps << ["hoe", "~> 3.13"]
 end
 
 namespace :spec do

--- a/spec/mailtrap/log_parser_spec.rb
+++ b/spec/mailtrap/log_parser_spec.rb
@@ -10,32 +10,32 @@ SAMPLE_EMPTY_LOG_FILENAME = File.join(LOG_DIR, 'sample_empty.log')
 describe Mailtrap::LogParser do
   it "should extract two emails from the sample log file" do
     emails = Mailtrap::LogParser.parse(SAMPLE_LOG_FILENAME)
-    emails.should have(2).elements
+    expect(emails.size).to eq(2)
   end
   
   it "should extract the details of each email" do
     emails = Mailtrap::LogParser.parse(SAMPLE_LOG_FILENAME)
     
     # let's just enough of TMail to know it's doing something useful...
-    emails[0].destinations.should == %w[ recipient@test.com ]
-    emails[1].destinations.should == %w[ bear@zoo.com giraffe@zoo.com ]
+    expect(emails[0].destinations).to eq %w[ recipient@test.com ]
+    expect(emails[1].destinations).to eq %w[ bear@zoo.com giraffe@zoo.com ]
     
-    emails[0].body.should include("Body content A")
-    emails[1].body.should include("Body content B")
+    expect(emails[0].body).to include("Body content A")
+    expect(emails[1].body).to include("Body content B")
   end
   
   it "should not include the message boundary lines" do
     emails = Mailtrap::LogParser.parse(SAMPLE_LOG_FILENAME)
     
-    emails[0].body.should_not include("* Message begins")
-    emails[0].body.should_not include("* Message ends")
+    expect(emails[0].body).to_not include("* Message begins")
+    expect(emails[0].body).to_not include("* Message ends")
     
-    emails[1].body.should_not include("* Message begins")
-    emails[1].body.should_not include("* Message ends")
+    expect(emails[1].body).to_not include("* Message begins")
+    expect(emails[1].body).to_not include("* Message ends")
   end
   
   it "should handle an empty file" do
     emails = Mailtrap::LogParser.parse(SAMPLE_EMPTY_LOG_FILENAME)
-    emails.should be_empty
+    expect(emails).to be_empty
   end
 end


### PR DESCRIPTION
Some errors were showing when running `rake spec` or `rake test`.  It seems to be a result of bit rot (external dependencies for `rspec`, `test/unit` & `hoe` gem changed, broke `rake test`).  The Hoe gem had some updates also which are due to rubyforge going away.

References:
- [theforeman#2514](http://projects.theforeman.org/issues/2514)
- [rspec/rspec-rails#758](https://github.com/rspec/rspec-rails/issues/758)
